### PR TITLE
make healthcheck and is_running endpoints optional using config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Optional:
 	* [use template engines](https://expressjs.com/en/guide/using-template-engines.html)
 * `STATIC_FOLDER`
 	* [serve static files](https://expressjs.com/en/starter/static-files.html)
+* `ADD_HEALTHCHECK`
+	* add `/healthcheck` endpoint which returns `OK` with status code 200
+* `ADD_IS_RUNNING`
+	* add `/is_running` endpoint which returns `OK` with status code 200
 
 
 #### Example

--- a/lib/app.js
+++ b/lib/app.js
@@ -155,11 +155,20 @@ const init = (config) => {
   }
 
   const healthcheck = (cb) => {
-    ['/healthcheck', '/is_running'].forEach((endpoint) => {
-      app.get(endpoint, (req, res, next) => {
+    const addHealthcheck = config.osseus_server.add_healthcheck
+    const addIsRunning = config.osseus_server.add_is_running
+
+    if (addHealthcheck) {
+      app.get('/healthcheck', (req, res, next) => {
         return res.send('OK')
       })
-    })
+    }
+
+    if (addIsRunning) {
+      app.get('/is_running', (req, res, next) => {
+        return res.send('OK')
+      })
+    }
 
     cb()
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osseus-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Osseus server",
   "scripts": {
     "build": "npm install",


### PR DESCRIPTION
## Proposed changes

`healthcheck` and `is_running` endpoints should be optional as each app can determine to do a more complex check and not just return `OK` immediately

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/colucom/osseus-server/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules